### PR TITLE
Fixes Issue #1 logout endpoint

### DIFF
--- a/backend/sightseeing_map/settings.py
+++ b/backend/sightseeing_map/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'users',
     'drf_yasg',
+    'rest_framework_simplejwt.token_blacklist', # Invalidates tokens (e.g., after logout)
 ]
 
 CORS_ALLOWED_ORIGINS = config('CORS_ALLOWED_ORIGINS', default='http://localhost:3000', cast=Csv())

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path 
-from .views import RegisterAPI, LoginAPI, UserAPI
+from .views import RegisterAPI, LoginAPI, UserAPI, LogoutAPI
 from rest_framework_simplejwt.views import TokenRefreshView
 
 urlpatterns = [
     path('users/register/', RegisterAPI.as_view(), name='user-register'),
     path('users/login/', LoginAPI.as_view(), name='user-login'),
+    path('users/logout/', LogoutAPI.as_view(), name='user-logout'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'), # Revise location if needed
     path('users/me/', UserAPI.as_view(), name='user-detail'),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -4,6 +4,8 @@ from rest_framework.views import APIView
 from .serializers import RegisterSerializer, LoginSerializer, UserSerializer 
 from django.contrib.auth.models import User
 from rest_framework_simplejwt.views import TokenRefreshView
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.exceptions import TokenError
 
 # Register API
 class RegisterAPI(generics.CreateAPIView):
@@ -37,3 +39,31 @@ class UserAPI(generics.RetrieveAPIView):
     def get_object(self):
         return self.request.user
     
+# Logout API
+class LogoutAPI(APIView):
+    '''
+    Logout a user by blacklisting the refresh token
+    '''
+    permission_classes = [permissions.IsAuthenticated] # Only authenticated users can logout
+
+    def post(self, request):
+        try:
+            # Extract the refresh token from the request
+            refresh_token = request.data.get("refresh")
+            if not refresh_token:
+                return Response({"error": "Refresh token is required"}, status=status.HTTP_400_BAD_REQUEST)
+            
+            # Blacklist the token
+            token = RefreshToken(refresh_token) 
+            token.blacklist()
+
+            # 205: Reset Content status code -> a request has been successfully processed and the client should reset the document view
+            return Response({"message": "Successfully logged out"}, status=status.HTTP_205_RESET_CONTENT)
+        except TokenError as e:
+            # Token-related errors for logging (not shown to users)
+            # Log errors for debugging
+            if "Token is blacklisted" in str(e):
+                print(f"Attempted reused of blacklisted token: {refresh_token}")
+            return Response({"message": "Logout failed"}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception:
+            return Response({"message": "Logout failed"}, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -43,6 +43,8 @@ class UserAPI(generics.RetrieveAPIView):
 class LogoutAPI(APIView):
     '''
     Logout a user by blacklisting the refresh token
+    This endpoint includes a simple error logging mechanism to log token-related errors 
+    For debugging purposes and can be removed or kept as needed
     '''
     permission_classes = [permissions.IsAuthenticated] # Only authenticated users can logout
 
@@ -60,7 +62,6 @@ class LogoutAPI(APIView):
             # 205: Reset Content status code -> a request has been successfully processed and the client should reset the document view
             return Response({"message": "Successfully logged out"}, status=status.HTTP_205_RESET_CONTENT)
         except TokenError as e:
-            # Token-related errors for logging (not shown to users)
             # Log errors for debugging
             if "Token is blacklisted" in str(e):
                 print(f"Attempted reused of blacklisted token: {refresh_token}")


### PR DESCRIPTION
## Description
This PR introduces a new API endpoint `/sightseeing/v1/users/logout/` which allows logged-in users to log out of their accounts, and invalidates the token once done so that it cannot be reused to enhance security. 

Additionally, it provides some simple debugging statements for developers to understand what is going on in the process of logging out.

- Related Issue: Closes #1 

## Changes Made
- Add `simplejwt.token_blacklist` in `settings.py` for token blacklisting
- Introduces `LogoutAPIView` for logging out and blacklisting tokens
- Makes available new API endpoint 

## Checklist
- [x] My code follows the project's code style.
- [x] I have tested my changes and they work as expected.
- [x] I have added necessary documentation (if applicable).
- [x] This PR is ready for review.

## Notes
1. **Endpoint**: `/sightseeing/v1/users/logout/`
2. **Method**: `POST`
3. **Request**:
   - Authorization header: `Bearer <access_token>`
   - Body: `{ "refresh": "<refresh_token>" }`
4. **Responses**:
   - `205 Reset Content`: Logout was successful. Message: `"Successfully logged out"`
   - `400 Bad Request`: Logout failed. Message: `"Logout failed"`

## Testing
- Tested using Postman with valid and invalid tokens.
- Verified token blacklisting by attempting to reuse a blacklisted refresh token.
